### PR TITLE
Add support for dashes

### DIFF
--- a/lib/selector-solver.js
+++ b/lib/selector-solver.js
@@ -33,9 +33,9 @@ SelectorSolver.prototype = {
     solveSelector: function (selector, solveTagsOnly) {
         if (solveTagsOnly || selector.indexOf(".") !== -1 || selector.indexOf("#") !== -1)
         {
-            var tag = /^[\w]*/.exec(selector)[0];
-            var id = (/#[\w]*/.exec(selector) || []).map(removeFirstChar)[0];
-            var classes = utils.reAllMatches(/(\.[\w]*)/g, selector).map(removeFirstChar);
+            var tag = /^[\w-]*/.exec(selector)[0];
+            var id = (/#[\w-]*/.exec(selector) || []).map(removeFirstChar)[0];
+            var classes = utils.reAllMatches(/(\.[\w-]*)/g, selector).map(removeFirstChar);
 
             if (tag)
             {


### PR DESCRIPTION
Add support for dashes in tag names, ids and classes. The `\w` matches only `[a-zA-z0-9_]`. Custom elements actually <em>require</em> you to put a dash in the tag name.
