### PR TITLE
Updated the '.workspace' selector

### DIFF
--- a/keymaps/selector-to-tag.cson
+++ b/keymaps/selector-to-tag.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace atom-text-editor:not([mini])':
+'atom-workspace atom-text-editor:not([mini])':
   'tab': 'selector-to-tag:solve-selector'


### PR DESCRIPTION
I replaced the deprecated '.workspace' selector with the new 'atom-workspace' selector to fix the following deprecation error:

"Use the `atom-workspace` tag instead of the `workspace` class."

https://atom.io/docs/v0.149.0/upgrading/upgrading-your-ui-theme
