### PR TITLE
Add option to expand block level tag to multiple lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## HEAD
+
+- Added option to expand block tags to multiple lines.
+
 ## 0.2.1
 
 - Fixed bug where starting a tag with dash (`-`) will crash the package

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Just type a CSS selector and press `TAB`:
 
  - **Close self-closing tags** - Add a backslash before the end of self-closing tags. For example `<link>` will be solved to `<link/>` *(Default: false)*
 
+ - **Expand block tags to multiple lines** - Puts the cursor and end tag on new lines. *(Default: false)*
+
+ - **Block-level elements** - If "Expand block tags to multiple lines" is checked, these tags will count as block tags. *(Default: address, article, aside, audio, blockquote, canvas, dd, div, dl, fieldset, figcaption, figure, footer, form, h1, h2, h3, h4, h5, h6, header, hgroup, hr, main, nav, noscript, ol, output, p, pre, section, table, tfoot, ul, video)*
+
 
 ## Supported selectors
 
@@ -22,4 +26,4 @@ For now the following selectors
  - \#id
  - .class
 
-If you have any sugesstions for other selectors or sugestions in general, please submit an issue.
+If you have any sugestions for other selectors or sugestions in general, please submit an issue.

--- a/lib/main.js
+++ b/lib/main.js
@@ -25,6 +25,13 @@ module.exports = {
       default: false,
       title: "Close self-closing tags",
       description: "Add a backslash before the end of self-closing tags"
+    },
+
+    expandBlockTags: {
+      type: "boolean",
+      default: false,
+      title: "Expand block tags to multiple lines",
+      description: "Put end tag on a new line"
     }
   },
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -32,6 +32,17 @@ module.exports = {
       default: false,
       title: "Expand block tags to multiple lines",
       description: "Put end tag on a new line"
+    },
+
+    blockTags: {
+      type: "array",
+      default: ["address", "article", "aside", "audio", "blockquote", "canvas",
+                "dd", "div", "dl", "fieldset", "figcaption", "figure", "footer",
+                "form", "h1", "h2", "h3", "h4", "h5", "h6", "header", "hgroup",
+                "hr", "main", "nav", "noscript", "ol", "output", "p", "pre",
+                "section", "table", "tfoot", "ul", "video"],
+      title: "Block-level elements",
+      description: "HTML tags that will be expanded to multiple lines."
     }
   },
 

--- a/lib/selector-solver.js
+++ b/lib/selector-solver.js
@@ -35,7 +35,11 @@ SelectorSolver.prototype = {
     return false;
   },
 
-  solveSelector: function (selector, solveTagsOnly, closeSelfclosingTags, expandBlockTags) {
+  solveSelector: function (selector, solveTagsOnly, closeSelfclosingTags, expandBlockTags, blockTags) {
+    if (typeof blockTags === 'undefined') {
+      blockTags = this.selfBlockTags
+    }
+
     if (solveTagsOnly || selector.indexOf(".") !== -1 || selector.indexOf("#") !== -1)
     {
       var tag = (/^\w[\w-]*/.exec(selector) || [])[0];
@@ -47,7 +51,7 @@ SelectorSolver.prototype = {
       if (tag)
       {
         isSelfClosing = this.selfClosingTags.indexOf(tag) !== -1;
-        isBlock = this.selfBlockTags.indexOf(tag) !== -1;
+        isBlock = blockTags.indexOf(tag) !== -1;
 
         var element = document.createElement(tag);
         if (id)
@@ -97,7 +101,8 @@ SelectorSolver.prototype = {
       var solvedElement = this.self.solveSelector(selector,
                                                   atom.config.get('selector-to-tag.solveTagsOnly'),
                                                   atom.config.get('selector-to-tag.closeSelfclosingTags'),
-                                                  expandBlockTags);
+                                                  expandBlockTags,
+                                                  atom.config.get('selector-to-tag.blockTags'));
 
       if (solvedElement)
       {

--- a/lib/selector-solver.js
+++ b/lib/selector-solver.js
@@ -12,6 +12,12 @@ function SelectorSolver() {
       "link", "meta", "param"
   ];
 
+  this.selfBlockTags = ["address", "article", "aside", "audio", "blockquote",
+      "canvas", "dd", "div", "dl", "fieldset", "figcaption", "figure", "footer",
+      "form", "h1", "h2", "h3", "h4", "h5", "h6", "header", "hgroup", "hr",
+      "main", "nav", "noscript", "ol", "output", "p", "pre", "section", "table",
+      "tfoot", "ul", "video"];
+
   atom.commands.add('atom-text-editor', {
       'selector-to-tag:solve-selector': utils.addSelf(this.handleCommand, this)
   });
@@ -29,18 +35,19 @@ SelectorSolver.prototype = {
     return false;
   },
 
-  solveSelector: function (selector, solveTagsOnly, closeSelfclosingTags) {
+  solveSelector: function (selector, solveTagsOnly, closeSelfclosingTags, expandBlockTags) {
     if (solveTagsOnly || selector.indexOf(".") !== -1 || selector.indexOf("#") !== -1)
     {
       var tag = (/^\w[\w-]*/.exec(selector) || [])[0];
       var id = (/#[\w-]*/.exec(selector) || []).map(removeFirstChar)[0];
       var classes = /(\.[\w-]*)/g.getAllMatches(selector).map(removeFirstChar);
 
-      var string, isSelfClosing;
+      var string, isSelfClosing, isBlock;
 
       if (tag)
       {
         isSelfClosing = this.selfClosingTags.indexOf(tag) !== -1;
+        isBlock = this.selfBlockTags.indexOf(tag) !== -1;
 
         var element = document.createElement(tag);
         if (id)
@@ -59,11 +66,16 @@ SelectorSolver.prototype = {
         {
           string = string.insertAt(string.length-1, "/");
         }
+        else if (isBlock && expandBlockTags)
+        {
+          string = string.insertAt(string.indexOf("</"), "\n\n");
+        }
 
         return {
           element: element,
           string: string,
-          isSelfClosing: isSelfClosing
+          isSelfClosing: isSelfClosing,
+          isBlock: isBlock
         };
       }
     }
@@ -80,28 +92,44 @@ SelectorSolver.prototype = {
       var textOnCurrentLine = editor.lineTextForBufferRow(cursorPosition.row);
       var textBeforeCursor = textOnCurrentLine.substring(0, cursorPosition.column);
       var selector = /[^\s]*$/.exec(textBeforeCursor)[0]; // last word before cursor
+      var expandBlockTags = atom.config.get('selector-to-tag.expandBlockTags');
 
       var solvedElement = this.self.solveSelector(selector,
                                                   atom.config.get('selector-to-tag.solveTagsOnly'),
-                                                  atom.config.get('selector-to-tag.closeSelfclosingTags'));
+                                                  atom.config.get('selector-to-tag.closeSelfclosingTags'),
+                                                  expandBlockTags);
 
       if (solvedElement)
       {
         var selectorRange = [[cursorPosition.row, cursorPosition.column - selector.length],
                               cursorPosition];
-        editor.setTextInBufferRange(selectorRange, solvedElement.string);
 
-        var newCursorPosition = editor.getCursorScreenPosition();
-
-        if (solvedElement.isSelfClosing)
+        if (expandBlockTags && solvedElement.isBlock)
         {
-          newCursorPosition.column -= atom.config.get('selector-to-tag.closeSelfclosingTags') ? 2 : 1;
-          editor.setCursorScreenPosition(newCursorPosition);
+          editor.transact(function () {
+            editor.setTextInBufferRange(selectorRange, solvedElement.string);
+            editor.selectUp();
+            editor.getLastSelection().autoIndentSelectedRows();
+            editor.clearSelections();
+            editor.moveToEndOfLine();
+          });
         }
         else
         {
-          newCursorPosition.column -= solvedElement.element.tagName.length + 3;
-          editor.setCursorScreenPosition(newCursorPosition);
+          editor.setTextInBufferRange(selectorRange, solvedElement.string);
+
+          var newCursorPosition = editor.getCursorScreenPosition();
+
+          if (solvedElement.isSelfClosing)
+          {
+            newCursorPosition.column -= atom.config.get('selector-to-tag.closeSelfclosingTags') ? 2 : 1;
+            editor.setCursorScreenPosition(newCursorPosition);
+          }
+          else
+          {
+            newCursorPosition.column -= solvedElement.element.tagName.length + 3;
+            editor.setCursorScreenPosition(newCursorPosition);
+          }
         }
       }
       else

--- a/spec/selector-solver-spec.js
+++ b/spec/selector-solver-spec.js
@@ -54,4 +54,10 @@ describe("Tag solver", function () {
   it("should close self-closing tags", function () {
     expect(solver.solveSelector("link", true, true).string).toBe('<link/>');
   });
+
+  describe("when expandBlockTags is true", function () {
+    it("should expand a div tag to multiple lines", function () {
+      expect(solver.solveSelector("div#mama", true, true, true).string).toBe('<div id="mama">\n\n</div>');
+    });
+  });
 })

--- a/spec/selector-solver-spec.js
+++ b/spec/selector-solver-spec.js
@@ -55,9 +55,7 @@ describe("Tag solver", function () {
     expect(solver.solveSelector("link", true, true).string).toBe('<link/>');
   });
 
-  describe("when expandBlockTags is true", function () {
-    it("should expand a div tag to multiple lines", function () {
-      expect(solver.solveSelector("div#mama", true, true, true).string).toBe('<div id="mama">\n\n</div>');
-    });
+  it("should expand block tags to multiple lines", function () {
+    expect(solver.solveSelector("div#mama", true, true, true, ['div']).string).toBe('<div id="mama">\n\n</div>');
   });
 })


### PR DESCRIPTION
Can you provide some feedback on this?

I had to use a little more API than what you had before because of the indenting.  I think it would be better to let Atom figure out the amount of spaces/tabs to indent than try to add that to the resultant string.

Also, I will add an option to change which html tags the user wants to expand to multple lines (`selfBlockTags`).  I pulled the current array from: https://developer.mozilla.org/en-US/docs/Web/HTML/Block-level_elements.
