### PR TITLE
Remove headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Selector          | Output
 
  - **Expand block tags to multiple lines** - Puts the cursor and end tag on new lines. *(Default: false)*
 
- - **Block-level elements** - If "Expand block tags to multiple lines" is checked, these tags will count as block tags. *(Default: address, article, aside, audio, blockquote, canvas, dd, div, dl, fieldset, figcaption, figure, footer, form, h1, h2, h3, h4, h5, h6, header, hgroup, hr, main, nav, noscript, ol, output, p, pre, section, table, tfoot, ul, video)*
+ - **Block-level elements** - If "Expand block tags to multiple lines" is checked, these tags will count as block tags. *(Default: address, article, aside, audio, blockquote, canvas, dd, div, dl, fieldset, figcaption, figure, footer, form, header, hgroup, hr, main, nav, noscript, ol, output, p, pre, section, table, tfoot, ul, video)*
 
 ##Support
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -37,8 +37,8 @@ module.exports = {
 		blockTags: {
 			type: "array",
 			default: ["address", "article", "aside", "audio", "blockquote", "canvas",
-			          "dd", "div", "dl", "fieldset", "figcaption", "figure", "footer",
-			          "form", "header", "hgroup", "hr", "main", "nav", "noscript",
+								"dd", "div", "dl", "fieldset", "figcaption", "figure", "footer",
+								"form", "header", "hgroup", "hr", "main", "nav", "noscript",
 								"ol", "output", "p", "pre", "section", "table", "tfoot", "ul",
 								"video"],
 			title: "Block-level elements",

--- a/lib/main.js
+++ b/lib/main.js
@@ -38,9 +38,9 @@ module.exports = {
 			type: "array",
 			default: ["address", "article", "aside", "audio", "blockquote", "canvas",
 			          "dd", "div", "dl", "fieldset", "figcaption", "figure", "footer",
-			          "form", "h1", "h2", "h3", "h4", "h5", "h6", "header", "hgroup",
-			          "hr", "main", "nav", "noscript", "ol", "output", "p", "pre",
-			          "section", "table", "tfoot", "ul", "video"],
+			          "form", "header", "hgroup", "hr", "main", "nav", "noscript",
+								"ol", "output", "p", "pre", "section", "table", "tfoot", "ul",
+								"video"],
 			title: "Block-level elements",
 			description: "HTML tags that will be expanded to multiple lines."
 		}

--- a/lib/selector-solver.js
+++ b/lib/selector-solver.js
@@ -12,11 +12,6 @@ function SelectorSolver() {
 			"link", "meta", "param"
 	];
 
-	this.selfBlockTags = ["address", "article", "aside", "audio", "blockquote",
-			"canvas", "dd", "div", "dl", "fieldset", "figcaption", "figure", "footer",
-			"form", "header", "hgroup", "hr", "main", "nav", "noscript", "ol",
-			"output", "p", "pre", "section", "table", "tfoot", "ul", "video"];
-
 	atom.commands.add('atom-text-editor', {
 			'selector-to-tag:solve-selector': utils.addSelf(this.handleCommand, this)
 	});
@@ -36,7 +31,7 @@ SelectorSolver.prototype = {
 
 	solveSelector: function (selector, solveTagsOnly, closeSelfclosingTags, expandBlockTags, blockTags) {
 		if (typeof blockTags === 'undefined') {
-			blockTags = this.selfBlockTags
+			blockTags = []
 		}
 
 		var tag = (/^\w[\w-]*/.exec(selector) || [])[0];


### PR DESCRIPTION
I removed the heading tags from the default block tags.  I also removed the unused SelectorSolver.selfBlockTags which causes confusion.  It was in there to make the tests pass.
