### PR TITLE
Added a 'activeForGrammar'

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -10,6 +10,12 @@ module.exports = {
 			description: "Solve even if the selector is only the tag with no id and/or class. Enabling this will basically override html-language package, so you could disable that package."
 		},
 
+		activeForGrammar: {
+			type: "boolean",
+			default: false,
+			title: "Only on HTML grammer",
+			description: "Active only if HTML grammer is selected. The \"file extensions\" option will be ignored if this is true.",
+		},
 		activeForFileTypes: {
 			type: "array",
 			default: ["htm", "html", "kit", "shtml", "tmpl", "tpl", "xhtml"],

--- a/lib/selector-solver.js
+++ b/lib/selector-solver.js
@@ -18,14 +18,20 @@ function SelectorSolver() {
 }
 
 SelectorSolver.prototype = {
-	isHTML: function (filename) {
-		var extension = filename.split(".");
-		if (extension.length > 1)
+	isHTML: function (filename, grammar) {
+		if(atom.config.get('selector-to-tag.activeForGrammar'))
 		{
-			extension = extension[extension.length - 1].toLowerCase();
-			return (atom.config.get('selector-to-tag.activeForFileTypes') || this.defaultFileTypes).indexOf(extension) !== -1;
+			// check for grammar
+			//console.log(grammar.toString());
+			return grammar == ".text.html.basic";
+		} else {
+			var extension = filename.split(".");
+			if (extension.length > 1)
+			{
+				extension = extension[extension.length - 1].toLowerCase();
+				return (atom.config.get('selector-to-tag.activeForFileTypes') || this.defaultFileTypes).indexOf(extension) !== -1;
+			}
 		}
-
 		return false;
 	},
 
@@ -85,7 +91,7 @@ SelectorSolver.prototype = {
 	handleCommand: function (event) {
 		var editor = this.getModel();
 
-		if (this.self.isHTML(editor.getTitle()))
+		if (this.self.isHTML(editor.getTitle(), editor.getRootScopeDescriptor()))
 		{
 			var cursorPosition = editor.getCursorBufferPosition();
 			var textOnCurrentLine = editor.lineTextForBufferRow(cursorPosition.row);


### PR DESCRIPTION
I think relying on atom's selected 'grammar' rather than file extensions is kinda better way to do it. I was getting annoyed from not being able to use this plugin unless the file is saved and has the 'html' extension.

I am completely new to atom and its plugins, so if I am doing something silly there, please excuse me.
